### PR TITLE
implement overrideMimeType

### DIFF
--- a/components/script/dom/webidls/XMLHttpRequest.webidl
+++ b/components/script/dom/webidls/XMLHttpRequest.webidl
@@ -65,7 +65,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
   readonly attribute ByteString statusText;
   ByteString? getResponseHeader(ByteString name);
   ByteString getAllResponseHeaders();
-  // void overrideMimeType(DOMString mime);
+  void overrideMimeType(DOMString mime);
   [SetterThrows]
            attribute XMLHttpRequestResponseType responseType;
   readonly attribute any response;

--- a/components/script/dom/webidls/XMLHttpRequest.webidl
+++ b/components/script/dom/webidls/XMLHttpRequest.webidl
@@ -65,6 +65,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
   readonly attribute ByteString statusText;
   ByteString? getResponseHeader(ByteString name);
   ByteString getAllResponseHeaders();
+  [Throws]
   void overrideMimeType(DOMString mime);
   [SetterThrows]
            attribute XMLHttpRequestResponseType responseType;

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -648,6 +648,10 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
         ByteString::new(self.filter_response_headers().to_string().into_bytes())
     }
 
+    // https://xhr.spec.whatwg.org/#the-overridemimetype()-method
+    fn OverrideMimeType(&self, mime: DOMString) {
+    }
+
     // https://xhr.spec.whatwg.org/#the-responsetype-attribute
     fn ResponseType(&self) -> XMLHttpRequestResponseType {
         self.response_type.get()

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -120,6 +120,9 @@ pub struct XMLHttpRequest {
     response_xml: MutNullableHeap<JS<Document>>,
     #[ignore_heap_size_of = "Defined in hyper"]
     response_headers: DOMRefCell<Headers>,
+    override_mime_type: DOMRefCell<DOMString>,
+    #[ignore_heap_size_of = "Defined in rust-encoding"]
+    override_charset: DOMRefCell<Option<EncodingRef>>,
 
     // Associated concepts
     request_method: DOMRefCell<Method>,
@@ -157,6 +160,8 @@ impl XMLHttpRequest {
             response_type: Cell::new(_empty),
             response_xml: Default::default(),
             response_headers: DOMRefCell::new(Headers::new()),
+            override_mime_type: DOMRefCell::new("".to_owned()),
+            override_charset: DOMRefCell::new(None),
 
             request_method: DOMRefCell::new(Method::Get),
             request_url: DOMRefCell::new(None),
@@ -649,7 +654,32 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
     }
 
     // https://xhr.spec.whatwg.org/#the-overridemimetype()-method
-    fn OverrideMimeType(&self, mime: DOMString) {
+    fn OverrideMimeType(&self, mime: DOMString) -> ErrorResult {
+	    match self.ready_state.get() {
+            XMLHttpRequestState::Loading | XMLHttpRequestState::Done => return Err(Error::InvalidState),
+	        _ => {},
+	    }
+	    let parsed_mime = mime.parse::<Mime>();
+        let override_mime;
+        match parsed_mime {
+            Err(_) => return Err(Error::Syntax),
+            Ok(valid_mime) => { override_mime = valid_mime },
+        }
+        match override_mime {
+            Mime(ref toplevel, ref sublevel, ref params) => { 
+                                                        let toplevel_mime = &toplevel.as_str().to_ascii_lowercase();
+                                                        let sublevel_mime = &sublevel.as_str().to_ascii_lowercase();
+                                                        *self.override_mime_type.borrow_mut() = format!("{}/{}", toplevel_mime, sublevel_mime);
+                                                        for &(ref name, ref value) in params {
+                                                            if name == &mime::Attr::Charset {
+                                                                let encoding =  encoding_from_whatwg_label(&value.to_string());
+                                                                *self.override_charset.borrow_mut() = if encoding.is_none() { *self.override_charset.borrow() } 
+                                                                                                      else { Some(encoding.unwrap()) };
+                                                            }
+                                                        }
+                                                        Ok(())
+                                                        },
+        }
     }
 
     // https://xhr.spec.whatwg.org/#the-responsetype-attribute

--- a/tests/wpt/metadata/XMLHttpRequest/interfaces.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/interfaces.html.ini
@@ -1,18 +1,9 @@
 [interfaces.html]
   type: testharness
-  [XMLHttpRequest interface: operation overrideMimeType(DOMString)]
-    expected: FAIL
-
-  [XMLHttpRequest interface: calling overrideMimeType(DOMString) on new XMLHttpRequest() with too few arguments must throw TypeError]
-    expected: FAIL
-
   [FormData interface: new FormData() must inherit property "getAll" with the proper type (4)]
     expected: FAIL
 
   [FormData interface: new FormData(form) must inherit property "getAll" with the proper type (4)]
-    expected: FAIL
-
-  [XMLHttpRequest interface: new XMLHttpRequest() must inherit property "overrideMimeType" with the proper type (20)]
     expected: FAIL
 
   [FormData interface: operation getAll(USVString)]

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-done-state.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-done-state.htm.ini
@@ -1,5 +1,0 @@
-[overridemimetype-done-state.htm]
-  type: testharness
-  [XMLHttpRequest: overrideMimeType() in DONE state]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-invalid-mime-type.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-invalid-mime-type.htm.ini
@@ -1,5 +1,0 @@
-[overridemimetype-invalid-mime-type.htm]
-  type: testharness
-  [XMLHttpRequest: overrideMimeType() in unsent state, invalid MIME types]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-loading-state.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-loading-state.htm.ini
@@ -1,5 +1,0 @@
-[overridemimetype-loading-state.htm]
-  type: testharness
-  [XMLHttpRequest: overrideMimeType() in LOADING state]
-    expected: FAIL
-


### PR DESCRIPTION
- Added new override_charset and override_mime_type fields to the XMLHttpRequest structure.
- Implemented overrideMimeType according to XHR specifications.
- Updated the test expectations.
