### PR TITLE
Update web-platform-tests expected data

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -44,6 +44,7 @@ use euclid::size::Size2D;
 use html5ever::tree_builder::QuirksMode;
 use hyper::header::Headers;
 use hyper::method::Method;
+use hyper::mime::Mime;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use js::jsapi::JS_CallUnbarrieredObjectTracer;
 use js::jsapi::{GCTraceKindToAscii, Heap, JSGCTraceKind, JSObject, JSTracer, JS_CallObjectTracer, JS_CallValueTracer};
@@ -308,6 +309,7 @@ no_jsmanaged_fields!(TimeProfilerChan);
 no_jsmanaged_fields!(MemProfilerChan);
 no_jsmanaged_fields!(PseudoElement);
 no_jsmanaged_fields!(Length);
+no_jsmanaged_fields!(Mime);
 
 impl JSTraceable for Box<ScriptChan + Send> {
     #[inline]

--- a/components/script/dom/webidls/XMLHttpRequest.webidl
+++ b/components/script/dom/webidls/XMLHttpRequest.webidl
@@ -65,7 +65,8 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
   readonly attribute ByteString statusText;
   ByteString? getResponseHeader(ByteString name);
   ByteString getAllResponseHeaders();
-  // void overrideMimeType(DOMString mime);
+  [Throws]
+  void overrideMimeType(DOMString mime);
   [SetterThrows]
            attribute XMLHttpRequestResponseType responseType;
   readonly attribute any response;

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -120,6 +120,9 @@ pub struct XMLHttpRequest {
     response_xml: MutNullableHeap<JS<Document>>,
     #[ignore_heap_size_of = "Defined in hyper"]
     response_headers: DOMRefCell<Headers>,
+    override_mime_type: DOMRefCell<Option<Mime>>,
+    #[ignore_heap_size_of = "Defined in rust-encoding"]
+    override_charset: DOMRefCell<Option<EncodingRef>>,
 
     // Associated concepts
     request_method: DOMRefCell<Method>,
@@ -157,6 +160,8 @@ impl XMLHttpRequest {
             response_type: Cell::new(_empty),
             response_xml: Default::default(),
             response_headers: DOMRefCell::new(Headers::new()),
+            override_mime_type: DOMRefCell::new(None),
+            override_charset: DOMRefCell::new(None),
 
             request_method: DOMRefCell::new(Method::Get),
             request_url: DOMRefCell::new(None),
@@ -647,6 +652,21 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
         ByteString::new(self.filter_response_headers().to_string().into_bytes())
     }
 
+    // https://xhr.spec.whatwg.org/#the-overridemimetype()-method
+    fn OverrideMimeType(&self, mime: DOMString) -> ErrorResult {
+        match self.ready_state.get() {
+            XMLHttpRequestState::Loading | XMLHttpRequestState::Done => return Err(Error::InvalidState),
+            _ => {},
+        }
+        let override_mime = try!(mime.parse::<Mime>().map_err(|_| Error::Syntax));
+        *self.override_mime_type.borrow_mut() = Some(override_mime.clone());
+        let value = override_mime.get_param(mime::Attr::Charset);
+        *self.override_charset.borrow_mut() = value.and_then(|value| {
+                encoding_from_whatwg_label(value)
+        });
+        Ok(())
+    }
+
     // https://xhr.spec.whatwg.org/#the-responsetype-attribute
     fn ResponseType(&self) -> XMLHttpRequestResponseType {
         self.response_type.get()
@@ -988,6 +1008,7 @@ impl XMLHttpRequest {
         }
     }
 
+    //FIXME: add support for override_mime_type and override_charset
     fn text_response(&self) -> DOMString {
         let mut encoding = UTF_8 as EncodingRef;
         match self.response_headers.borrow().get() {

--- a/tests/wpt/metadata/XMLHttpRequest/event-upload-progress-crossorigin.sub.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/event-upload-progress-crossorigin.sub.htm.ini
@@ -1,0 +1,6 @@
+[event-upload-progress-crossorigin.sub.htm]
+  type: testharness
+  expected: TIMEOUT
+  [XMLHttpRequest: upload progress event for cross-origin requests]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/XMLHttpRequest/interfaces.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/interfaces.html.ini
@@ -1,18 +1,9 @@
 [interfaces.html]
   type: testharness
-  [XMLHttpRequest interface: operation overrideMimeType(DOMString)]
-    expected: FAIL
-
-  [XMLHttpRequest interface: calling overrideMimeType(DOMString) on new XMLHttpRequest() with too few arguments must throw TypeError]
-    expected: FAIL
-
   [FormData interface: new FormData() must inherit property "getAll" with the proper type (4)]
     expected: FAIL
 
   [FormData interface: new FormData(form) must inherit property "getAll" with the proper type (4)]
-    expected: FAIL
-
-  [XMLHttpRequest interface: new XMLHttpRequest() must inherit property "overrideMimeType" with the proper type (20)]
     expected: FAIL
 
   [FormData interface: operation getAll(USVString)]

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-done-state.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-done-state.htm.ini
@@ -1,5 +1,0 @@
-[overridemimetype-done-state.htm]
-  type: testharness
-  [XMLHttpRequest: overrideMimeType() in DONE state]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-invalid-mime-type.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-invalid-mime-type.htm.ini
@@ -1,5 +1,0 @@
-[overridemimetype-invalid-mime-type.htm]
-  type: testharness
-  [XMLHttpRequest: overrideMimeType() in unsent state, invalid MIME types]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-loading-state.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-loading-state.htm.ini
@@ -1,5 +1,0 @@
-[overridemimetype-loading-state.htm]
-  type: testharness
-  [XMLHttpRequest: overrideMimeType() in LOADING state]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-open-state-force-utf-8.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-open-state-force-utf-8.htm.ini
@@ -1,5 +1,6 @@
 [overridemimetype-open-state-force-utf-8.htm]
   type: testharness
+  expected: CRASH
   [XMLHttpRequest: overrideMimeType() in open state, enforcing UTF-8 encoding]
     expected: FAIL
 

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-open-state-force-xml.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-open-state-force-xml.htm.ini
@@ -1,5 +1,6 @@
 [overridemimetype-open-state-force-xml.htm]
   type: testharness
+  expected: TIMEOUT
   [XMLHttpRequest: overrideMimeType() in open state, XML MIME type with UTF-8 charset]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-unsent-state-force-shiftjis.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-unsent-state-force-shiftjis.htm.ini
@@ -1,5 +1,6 @@
 [overridemimetype-unsent-state-force-shiftjis.htm]
   type: testharness
+  expected: CRASH
   [XMLHttpRequest: overrideMimeType() in unsent state, enforcing Shift-JIS encoding]
     expected: FAIL
 

--- a/tests/wpt/metadata/XMLHttpRequest/send-after-setting-document-domain.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-after-setting-document-domain.htm.ini
@@ -1,5 +1,6 @@
 [send-after-setting-document-domain.htm]
   type: testharness
+  expected: TIMEOUT
   [loading documents from original origin after setting document.domain]
     expected: FAIL
 

--- a/tests/wpt/metadata/XMLHttpRequest/send-redirect-bogus-sync.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-redirect-bogus-sync.htm.ini
@@ -1,0 +1,8 @@
+[send-redirect-bogus-sync.htm]
+  type: testharness
+  [XMLHttpRequest: send() - Redirects (bogus Location header; sync) (302: http://z)]
+    expected: FAIL
+
+  [XMLHttpRequest: send() - Redirects (bogus Location header; sync) (303: http://z)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/XMLHttpRequest/send-redirect-bogus.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-redirect-bogus.htm.ini
@@ -1,0 +1,8 @@
+[send-redirect-bogus.htm]
+  type: testharness
+  [XMLHttpRequest: send() - Redirects (bogus Location header) (302: http://example.not)]
+    expected: FAIL
+
+  [XMLHttpRequest: send() - Redirects (bogus Location header) (303: http://example.not)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/semantics/forms/the-select-element/select-ask-for-reset.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-select-element/select-ask-for-reset.html.ini
@@ -2,3 +2,4 @@
   type: testharness
   [ask for reset on node remove, non multiple.]
     expected: FAIL
+


### PR DESCRIPTION
Updated the tests expectations by running `./mach test-wpt XMLHttpRequest/ --log-raw /tmp/servo.log`, followed by `./mach update-wpt /tmp/servo.log`.
